### PR TITLE
fix: duplicate entity due to collection naming

### DIFF
--- a/collection/generator/collection_loader_test.go
+++ b/collection/generator/collection_loader_test.go
@@ -1,0 +1,255 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/amirkode/go-mongr8/internal/config"
+	"github.com/amirkode/go-mongr8/internal/util"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func testSetupCollectionFolder() {
+	rootPath, err := config.GetProjectRootDir()
+	if err != nil {
+		panic(err)
+	}
+
+	path := fmt.Sprintf("%s/%s/no_edit", *rootPath, baseCollectionPath)
+	if config.DoesPathExist(path) {
+		return
+	}
+
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		panic(err)
+	}
+
+	// init combined collection
+	tplVar := struct {
+		CreateDate string
+	}{
+		CreateDate: time.Now().Format("2006-01-02"),
+	}
+
+	tplPath := fmt.Sprintf("%s/migration/init/template.tpl", *rootPath)
+	outputPath := fmt.Sprintf("%s/mongr8/collection/no_edit/combined_collections.go", *rootPath)
+	err = util.GenerateTemplate(tplCombainedCollections, tplPath, outputPath, tplVar, true)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func testSetupCollection(collectionName string) {
+	testSetupCollectionFolder()
+
+	rootPath, err := config.GetProjectRootDir()
+	if err != nil {
+		panic(err)
+	}
+
+	tplPath := fmt.Sprintf("%s/collection/generator/template.tpl", *rootPath)
+	collectionName = util.ToSnakeCase(collectionName)
+	templateVar := &CollectionTemplateVar{
+		CreateDate: time.Now().Format("2006-01-02"),
+		Entity:     util.ToCapitalizedCamelCase(collectionName),
+		Collection: collectionName,
+	}
+
+	// genenrate collection
+	outputPath := fmt.Sprintf("%s/mongr8/collection/%s.go", *rootPath, collectionName)
+	err = util.GenerateTemplate(tplCollection, tplPath, outputPath, templateVar, true)
+	if err != nil {
+		panic(err)
+	}
+
+	// generate combined collections
+	combinedCollsTemplateVar, err := getCombinedCollectionsTemplateVar(*rootPath)
+	if err != nil {
+		panic(err)
+	}
+
+	outputPath = fmt.Sprintf("%s/mongr8/collection/no_edit/combined_collections.go", *rootPath)
+	err = util.GenerateTemplate(tplCombainedCollections, tplPath, outputPath, combinedCollsTemplateVar, true)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func testTearDown() {
+	rootPath, err := config.GetProjectRootDir()
+	if err != nil {
+		panic(err)
+	}
+
+	path := fmt.Sprintf("%s/%s", *rootPath, baseCollectionPath)
+	if err := os.RemoveAll(path); err != nil {
+		panic(err)
+	}
+}
+
+func TestGetAllCollectionStructs(t *testing.T) {
+	Convey("Case 1: Normal", t, func() {
+		testTearDown()
+		testSetupCollection("first_collection")
+		testSetupCollection("second_collection")
+		
+		collectionStructs := getAllCollectionStructs()
+		Convey("Unexpected collection structs length", func() {
+			So(len(collectionStructs), ShouldEqual, 2)
+		})
+
+		expectedStructs := map[string]bool{
+			"FirstCollection": true,
+			"SecondCollection": true,
+		}
+
+		Convey("Unexpected struct name", func() {
+			for _, name := range collectionStructs {
+				_, ok := expectedStructs[name]
+				So(ok, ShouldBeTrue)
+			}
+		})
+	})
+}
+
+func TestGetCollectionStructName(t *testing.T) {
+	Convey("Case 1: Normal", t, func() {
+		testTearDown()
+		rootPath, err := config.GetProjectRootDir()
+		if err != nil {
+			panic(err)
+		}
+
+		testSetupCollection("first_collection")
+		testSetupCollection("second_collection")
+
+		Convey("Unexpected struct name", func() {
+			coll1Path := fmt.Sprintf("%s/%s/first_collection.go", *rootPath, baseCollectionPath)
+			name1, err := getCollectionStructName(coll1Path)
+			if err != nil {
+				panic(err)
+			}
+
+			So(*name1, ShouldEqual, "FirstCollection")
+
+			coll2Path := fmt.Sprintf("%s/%s/second_collection.go", *rootPath, baseCollectionPath)
+			name2, err := getCollectionStructName(coll2Path)
+			if err != nil {
+				panic(err)
+			}
+
+			So(*name2, ShouldEqual, "SecondCollection")
+		})
+	})
+}
+
+func TestGetAllCollectionNames(t *testing.T) {
+	Convey("Case 1: Normal snake case input", t, func() {
+		testTearDown()
+		testSetupCollection("first_collection")
+		testSetupCollection("second_collection")
+		
+		collectionNames := getAllCollectionNames()
+		Convey("Unexpected collection names length", func() {
+			So(len(collectionNames), ShouldEqual, 2)
+		})
+
+		expectedNames := map[string]bool{
+			"first_collection": true,
+			"second_collection": true,
+		}
+
+		Convey("Unexpected collection name", func() {
+			for _, name := range collectionNames {
+				_, ok := expectedNames[name]
+				So(ok, ShouldBeTrue)
+			}
+		})
+	})
+
+	Convey("Case 2: Camel case input", t, func() {
+		testTearDown()
+		testSetupCollection("FirstCollection")
+		testSetupCollection("SecondCollection")
+		
+		collectionNames := getAllCollectionNames()
+		Convey("Unexpected collection names length", func() {
+			So(len(collectionNames), ShouldEqual, 2)
+		})
+
+		expectedNames := map[string]bool{
+			"firstcollection": true,
+			"secondcollection": true,
+		}
+
+		Convey("Unexpected collection name", func() {
+			for _, name := range collectionNames {
+				_, ok := expectedNames[name]
+				So(ok, ShouldBeTrue)
+			}
+		})
+	})
+}
+
+func TestGetCollectionName(t *testing.T) {
+	Convey("Case 1: Normal snake case input", t, func() {
+		testTearDown()
+		rootPath, err := config.GetProjectRootDir()
+		if err != nil {
+			panic(err)
+		}
+
+		testSetupCollection("first_collection")
+		testSetupCollection("second_collection")
+
+		Convey("Unexpected collection name", func() {
+			coll1Path := fmt.Sprintf("%s/%s/first_collection.go", *rootPath, baseCollectionPath)
+			name1, err := getCollectionName(coll1Path)
+			if err != nil {
+				panic(err)
+			}
+
+			So(*name1, ShouldEqual, "first_collection")
+
+			coll2Path := fmt.Sprintf("%s/%s/second_collection.go", *rootPath, baseCollectionPath)
+			name2, err := getCollectionName(coll2Path)
+			if err != nil {
+				panic(err)
+			}
+
+			So(*name2, ShouldEqual, "second_collection")
+		})
+	})
+
+	Convey("Case 2: Camel case input", t, func() {
+		testTearDown()
+		rootPath, err := config.GetProjectRootDir()
+		if err != nil {
+			panic(err)
+		}
+
+		testSetupCollection("FirstCollection")
+		testSetupCollection("SecondCollection")
+
+		Convey("Unexpected collection name", func() {
+			coll1Path := fmt.Sprintf("%s/%s/firstcollection.go", *rootPath, baseCollectionPath)
+			name1, err := getCollectionName(coll1Path)
+			if err != nil {
+				panic(err)
+			}
+
+			So(*name1, ShouldEqual, "firstcollection")
+
+			coll2Path := fmt.Sprintf("%s/%s/secondcollection.go", *rootPath, baseCollectionPath)
+			name2, err := getCollectionName(coll2Path)
+			if err != nil {
+				panic(err)
+			}
+
+			So(*name2, ShouldEqual, "secondcollection")
+		})
+	})
+}

--- a/collection/generator/generator_test.go
+++ b/collection/generator/generator_test.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetCollectionTemplateVar(t *testing.T) {
+	Convey("Case 1: Normal snake case input", t, func() {
+		templ, err := getCollectionTemplateVar("a_collection")
+		if err != nil {
+			panic(err)
+		}
+
+		Convey("Unexpected collection name", func() {
+			So(templ.Collection, ShouldEqual, "a_collection")
+		})
+		Convey("Unexpected entity name", func() {
+			So(templ.Entity, ShouldEqual, "ACollection")
+		})
+	})
+
+	Convey("Case 2: Camel case input", t, func() {
+		templ, err := getCollectionTemplateVar("CollectionOne")
+		if err != nil {
+			panic(err)
+		}
+
+		Convey("Unexpected collection name", func() {
+			So(templ.Collection, ShouldEqual, "collectionone")
+		})
+		Convey("Unexpected entity name", func() {
+			So(templ.Entity, ShouldEqual, "Collectionone")
+		})
+	})
+
+	Convey("Case 3: Cluttered input", t, func() {
+		templ, err := getCollectionTemplateVar("_Collection-One*&#")
+		if err != nil {
+			panic(err)
+		}
+
+		Convey("Unexpected collection name", func() {
+			So(templ.Collection, ShouldEqual, "collection_one")
+		})
+		Convey("Unexpected entity name", func() {
+			So(templ.Entity, ShouldEqual, "CollectionOne")
+		})
+	})
+}
+
+func TestGetCombinedCollectionsTemplateVar(t *testing.T) {
+	// TODO: implement test
+}
+
+func TestGenerateMigrationTemplate(t *testing.T) {
+	// TODO: implement test
+}

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -14,26 +14,70 @@ import (
 )
 
 func capitalizeFirstLetter(s string, lowerRest bool) string {
-    if len(s) == 0 {
-        return s
-    }
+	if len(s) == 0 {
+		return s
+	}
 
 	rest := s[1:]
 	if lowerRest {
 		rest = strings.ToLower(rest)
 	}
 
-    return strings.ToUpper(s[0:1]) + rest
+	return strings.ToUpper(s[0:1]) + rest
 }
 
 func checkSnakeCase(s string) error {
-    pattern := `^([a-zA-Z].*[a-zA-Z0-9])+(_([a-zA-Z].*[a-zA-Z0-9])+)*$`
+	pattern := `^([a-zA-Z].*[a-zA-Z0-9])+(_([a-zA-Z].*[a-zA-Z0-9])+)*$`
 	reg := regexp.MustCompile(pattern)
 	if !reg.MatchString(s) {
-		return errors.New("The provided string is not a valid Snake-case style string")
+		return errors.New("the provided string is not a valid Snake-case style string")
 	}
 
 	return nil
+}
+
+// This split string into a slice of smaller strings
+// by an exception function comparator
+// Example:
+// - exceptFunc: returns true if the char is alpha numeric
+// - source: "hello world, let's make a better-world"
+// - return: ["hello", "world", "let", "s", "make", "a", "better", "world"]
+func splitStringByExcept(exceptFunc func(rune) bool, source string) []string {
+	res := make([]string, 0)
+	curr := ""
+	for _, c := range source {
+		if exceptFunc(c) {
+			curr += string(c)
+		} else if curr != "" {
+			res = append(res, curr)
+			curr = ""
+		}
+	}
+
+	// append the last one
+	if curr != "" {
+		res = append(res, curr)
+	}
+
+	return res
+}
+
+func ToSnakeCase(s string) string {
+	alphaNumericRegex := regexp.MustCompile(`^[a-zA-Z0-9]$`)
+	var splitted = splitStringByExcept(func(r rune) bool {
+		return alphaNumericRegex.MatchString(string(r))
+	}, s)
+
+	res := ""
+	// could have used `strings.Join`, but it need to be lowercase
+	for idx, currSplit := range splitted {
+		res += strings.ToLower(currSplit)
+		if idx < len(splitted)-1 {
+			res += "_"
+		}
+	}
+
+	return res
 }
 
 func ToCapitalizedCamelCase(s string) string {
@@ -43,7 +87,7 @@ func ToCapitalizedCamelCase(s string) string {
 	} else {
 		splitted = strings.Split(s, " ")
 	}
-	
+
 	res := ""
 	for _, currSplit := range splitted {
 		res += capitalizeFirstLetter(currSplit, true)


### PR DESCRIPTION
Background:
When we want to create a collection, sometimes we have got our own preference e.g: snake case or camel casing naming. But, to avoid duplication. It needs to standardize the naming mechanism.

Changes:
- Always convert any collection name (including any random ASCII char) input to snake case (at least for a temporary standard).
- Add duplicate validation

Impacts:
- New standard for a collection name
- Avoid collection name duplication.